### PR TITLE
Enable dragging to board- Closes #3, Closes #7

### DIFF
--- a/src/board.css
+++ b/src/board.css
@@ -1,4 +1,5 @@
 .board {
   background-color: #b7bebe;
   text-align: center;
+  height: 50px;
 }

--- a/src/board.jsx
+++ b/src/board.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 
 import "./board.css";
+import { Domino, Horizontal, Vertical } from "./domino/domino.jsx"
 
 class Board extends Component {
   constructor(props) {
@@ -9,8 +10,32 @@ class Board extends Component {
     };
   }
 
+  getDominoes() {
+    return (
+      this.props.dominoes.map((domino) => (
+        <td key={domino}>
+          <Domino direction={Horizontal} dots={domino} />
+        </td>
+      ))
+    );
+  }
+
+  getBoard() {
+    return (
+      <div className="board">
+        <table>
+          <tbody>
+            <tr>
+              {this.getDominoes()}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
   render() {
-    return (<div className="board">Board is empty at the moment</div>);
+    return (this.getBoard());
   }
 }
 

--- a/src/domino/domino.jsx
+++ b/src/domino/domino.jsx
@@ -22,12 +22,14 @@ class Domino extends Component {
 
   render() {
     let [dir1, dir2] = this.getDirections();
+    let dots1 = Math.floor(this.props.dots / 10);
+    let dots2 = Math.floor(this.props.dots % 10);
     return (
       <table className="domino">
         <tbody>
           <tr>
-            <td><HalfDomino direction={dir1} value={this.props.dots1} /></td>
-            <td><HalfDomino direction={dir2} value={this.props.dots2} /></td>
+            <td><HalfDomino direction={dir1} value={dots1} /></td>
+            <td><HalfDomino direction={dir2} value={dots2} /></td>
           </tr>
         </tbody>
       </table>
@@ -37,8 +39,7 @@ class Domino extends Component {
 
 Domino.propTypes = {
   direction: PropTypes.oneOf([Horizontal, Vertical]).isRequired,
-  dots1: PropTypes.number.isRequired,
-  dots2: PropTypes.number.isRequired,
+  dots: PropTypes.number.isRequired,
 }
 
 export { Domino, Horizontal, Vertical };

--- a/src/game.jsx
+++ b/src/game.jsx
@@ -7,36 +7,69 @@ import ImageHeadline from "./dominoes-header.jpg"
 
 const PlayerInitialDominoesCount = 6;
 const AllDominoes = [
-  [0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6],
-  [1, 1], [1, 2], [1, 3], [1, 4], [1, 5], [1, 6],
-  [2, 2], [2, 3], [2, 4], [2, 5], [2, 6],
-  [3, 3], [3, 4], [3, 5], [3, 6],
-  [4, 4], [4, 5], [4, 6],
-  [5, 5], [5, 6],
-  [6, 6]
-];
+  0, 1, 2, 3, 4, 5, 6,
+  11, 12, 13, 14, 15, 16,
+  22, 23, 24, 25, 26,
+  33, 34, 35, 36,
+  44, 45, 46,
+  55, 56,
+  66,
+]
 
 class Game extends Component {
   constructor(props) {
     super(props);
-    let randomPlayer1Dominoes = Array.from(
-      { length: PlayerInitialDominoesCount },
-      (v, i) => Math.floor(Math.random() * AllDominoes.length)
-    );
+    let randomPlayer1DominoesIndexes = this.getRandomPlayer1DominoesIndexes();
     this.state = {
-      player1Deck: AllDominoes.filter((item, i) => randomPlayer1Dominoes.includes(i)),
-      bank: AllDominoes.filter((item, i) => !randomPlayer1Dominoes.includes(i)),
+      player1Deck: AllDominoes.filter(
+        (_, i) => randomPlayer1DominoesIndexes.includes(i)),
+      bank: AllDominoes.filter(
+        (_, i) => !randomPlayer1DominoesIndexes.includes(i)),
+      board: [],
     };
+  }
+
+  getRandomPlayer1DominoesIndexes() {
+    var randomPlayer1DominoesIndexes = []
+    while (randomPlayer1DominoesIndexes.length < PlayerInitialDominoesCount) {
+      var randIndex = Math.floor(Math.random() * AllDominoes.length) + 1;
+      if (!randomPlayer1DominoesIndexes.includes(randIndex)) {
+        randomPlayer1DominoesIndexes.push(randIndex);
+      }
+    }
+    return randomPlayer1DominoesIndexes;
+  }
+
+  onDragOver(ev) {
+    return (ev.preventDefault());
+  }
+
+  onDrop(ev) {
+    let idDropped = parseInt(ev.dataTransfer.getData("id"));
+
+    this.setState({
+      player1Deck: this.state.player1Deck.filter((item) => item != idDropped),
+      board: this.state.board.concat(idDropped),
+      bank: this.state.bank,
+    })
   }
 
   render() {
     return (
       <div>
         <h1>Dominoes <img src={ImageHeadline} /> Game!</h1>
-        <h2>board:</h2><Board />
+        <h2>board:</h2>
+        <div
+          onDragOver={(e) => this.onDragOver(e)}
+          onDrop={(e) => this.onDrop(e)}
+        >
+          <Board dominoes={this.state.board} />
+        </div>
         <h2>Player deck:</h2>
-        <PlayerDeck dominoes={this.state.player1Deck} />
-      </div>
+        <div onDragOver={(e) => this.onDragOver(e)}>
+          <PlayerDeck dominoes={this.state.player1Deck} />
+        </div>
+      </div >
     );
   }
 }

--- a/src/playerDeck.jsx
+++ b/src/playerDeck.jsx
@@ -10,17 +10,21 @@ class PlayerDeck extends Component {
     };
   }
 
+  onDragStart(ev, id) {
+    ev.dataTransfer.setData("id", id);
+  }
+
   getDominoes() {
     return (
-      this.props.dominoes.map((domino, i) => (
-        <td key={i}>
-          <Domino direction={Horizontal} dots1={domino[0]} dots2={domino[1]} />
+      this.props.dominoes.map((domino) => (
+        <td key={domino} onDragStart={(e) => this.onDragStart(e, domino)} draggable>
+          <Domino direction={Horizontal} dots={domino} />
         </td>
       ))
     );
   }
 
-  getInitialDeck() {
+  getDeck() {
     return (
       <div className="player-deck">
         <table>
@@ -35,7 +39,7 @@ class PlayerDeck extends Component {
   }
 
   render() {
-    return (this.getInitialDeck());
+    return (this.getDeck());
   }
 }
 


### PR DESCRIPTION
Now you can grab a domino and drag it to the board area:
![image](https://user-images.githubusercontent.com/4006829/56430056-c71e9a00-62cd-11e9-8455-4a028d4cc2a3.png)

Then after drop the end state is:
![image](https://user-images.githubusercontent.com/4006829/56430072-d43b8900-62cd-11e9-80e2-b8ef5c9da043.png)

Required some fixes from the previous commit. Dominoes are being represented as an int for the purpose of easy ID management.